### PR TITLE
AboutWindow: Refactor and clean up Credits page

### DIFF
--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using Eto.Drawing;
 using Eto.Forms;
 
@@ -10,9 +10,12 @@ namespace OpenTabletDriver.UX.Windows
         const int FONTSIZE = LARGE_FONTSIZE - 4;
         const int SPACING = 10;
 
-        private readonly string[] Developers = ["InfinityGhost", "X9VoiD", "gonX", "jamesbt365", "Kuuube", "AkiSakurai"];
-        private readonly string[] Designers = ["InfinityGhost"];
-        private readonly string[] Documenters = ["InfinityGhost", "gonX", "jamesbt365", "Kuuube"];
+        private static readonly Dictionary<string, IReadOnlyList<string>> Contributors = new()
+        {
+            { "Developers", ["InfinityGhost", "X9VoiD", "gonX", "jamesbt365", "Kuuube", "AkiSakurai"] },
+            { "Designers", ["InfinityGhost"] },
+            { "Documenters", ["InfinityGhost", "gonX", "jamesbt365", "Kuuube"] }
+        };
 
         public AboutWindow()
             : base(Application.Instance.MainForm)
@@ -22,8 +25,7 @@ namespace OpenTabletDriver.UX.Windows
             var aboutTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Center,
-                VerticalContentAlignment = VerticalAlignment.Stretch,
-                Width = 500,
+                VerticalContentAlignment = VerticalAlignment.Center,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
                 Items =
@@ -56,59 +58,20 @@ namespace OpenTabletDriver.UX.Windows
                 }
             };
 
-            var creditsTabContent = new StackLayout
-            {
-                HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                VerticalContentAlignment = VerticalAlignment.Stretch,
-                Padding = SPACING,
-                Spacing = SPACING / 2,
-                Items =
-                {
-                    new Label
-                    {
-                        Text = $"OpenTabletDriver v{App.Version} Credits",
-                        VerticalAlignment = VerticalAlignment.Center,
-                        TextAlignment = TextAlignment.Center,
-                        Font = SystemFonts.Bold(FONTSIZE),
-                    },
-                    new StackLayoutItem {
-                        Expand = true,
-                        Control = new TextArea
-                        {
-                            ReadOnly = true,
-                            Text = "Developers:" + Environment.NewLine + string.Join(Environment.NewLine, Developers) + Environment.NewLine + Environment.NewLine
-                                    + "Designers:" + Environment.NewLine + string.Join(Environment.NewLine, Designers) + Environment.NewLine + Environment.NewLine
-                                    + "Documenters:" + Environment.NewLine + string.Join(Environment.NewLine, Documenters)
-                        }
-                    }
-                }
-            };
+            var creditsTabContent = GenerateAboutPageStackLayout();
+            creditsTabContent.Items.Add(GenerateHeaderLabel("Credits"));
+            AppendContributors(ref creditsTabContent);
 
-            var licenseTabContent = new StackLayout
-            {
-                HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                VerticalContentAlignment = VerticalAlignment.Stretch,
-                Padding = SPACING,
-                Spacing = SPACING / 2,
-                Items =
+            var licenseTabContent = GenerateAboutPageStackLayout();
+            licenseTabContent.Items.Add(GenerateHeaderLabel("License"));
+            licenseTabContent.Items.Add(new StackLayoutItem {
+                Expand = true,
+                Control = new TextArea
                 {
-                    new Label
-                    {
-                        Text = $"OpenTabletDriver v{App.Version} License",
-                        VerticalAlignment = VerticalAlignment.Center,
-                        TextAlignment = TextAlignment.Center,
-                        Font = SystemFonts.Bold(FONTSIZE),
-                    },
-                    new StackLayoutItem {
-                        Expand = true,
-                        Control = new TextArea
-                        {
-                            ReadOnly = true,
-                            Text = App.License,
-                        }
-                    }
+                    ReadOnly = true,
+                    Text = App.License,
                 }
-            };
+            });
 
             var tabControl = new TabControl();
             tabControl.Pages.Add(new TabPage(aboutTabContent) { Text = "About" });
@@ -117,5 +80,46 @@ namespace OpenTabletDriver.UX.Windows
 
             this.Content = tabControl;
         }
+
+        private static void AppendContributors(ref StackLayout layout)
+        {
+            foreach (var contributorGroup in Contributors)
+            {
+                var sl = GenerateAboutPageStackLayout();
+
+                sl.Items.Add(new Label
+                {
+                    Font = SystemFonts.Bold(LARGE_FONTSIZE),
+                    Text = contributorGroup.Key,
+                    TextAlignment = TextAlignment.Center,
+                });
+
+                foreach (string contributor in contributorGroup.Value)
+                    sl.Items.Add(new Label
+                    {
+                        TextAlignment = TextAlignment.Center,
+                        Text = contributor
+                    });
+
+                layout.Items.Add(sl);
+            }
+        }
+
+        private static Label GenerateHeaderLabel(string title) => new()
+            {
+                Text = $"OpenTabletDriver v{App.Version} {title}",
+                VerticalAlignment = VerticalAlignment.Center,
+                TextAlignment = TextAlignment.Center,
+                Font = SystemFonts.Bold(FONTSIZE),
+                Width = 250,
+            };
+
+        private static StackLayout GenerateAboutPageStackLayout() => new()
+            {
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                Padding = SPACING,
+                Spacing = SPACING / 2,
+                Width = 500,
+            };
     }
 }


### PR DESCRIPTION
This refactors some repeated invocations into functions, and changes the look of the Credits page:
<img width="504" height="457" alt="image" src="https://github.com/user-attachments/assets/eeac995e-e35f-4a4e-b4b7-a6135f420e30" />


